### PR TITLE
Add TinyTools to Branding & Media Processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Ship it! Deploy your app globally in minutes with these platforms.
 | [Looka](https://looka.com/) | Logo maker with branding assets |
 | [Logo.surf](https://logo.surf/) | Simple text-based logo generator |
 | [Favicon Generator](https://realfavicongenerator.net/) | Multi-platform favicon generation |
+| [TinyTools](https://tinytools-smoky.vercel.app/) | Free favicon generator + color palette generator + domain name generator (no signup, browser-based, open source) |
 | [CloudConvert](https://cloudconvert.com/) | Convert between SVG, PNG, ICO, etc. |
 
 ### Icon Libraries
@@ -311,6 +312,7 @@ Ship it! Deploy your app globally in minutes with these platforms.
 | [CloudConvert](https://cloudconvert.com/) | Universal file converter |
 | [Gifski](https://gif.ski/) | Convert videos to high-quality GIFs |
 | [OG Image Playground](https://og-playground.vercel.app/) | Generate Open Graph images |
+| [TinyTools](https://tinytools-smoky.vercel.app/) | Free OG image generator + AI background remover (runs locally in-browser, no upload, no signup) |
 
 ## Screen Recording
 


### PR DESCRIPTION
Hi! Thanks for maintaining this great list 🙌

This PR adds [TinyTools](https://tinytools-smoky.vercel.app/) — a small open-source collection of free, single-purpose web utilities that run entirely in the browser (no signup, no upload, MIT licensed). Adds it to two relevant sections:

**Branding & Design Assets > Logo Design & Generation** — TinyTools includes a favicon generator, color palette generator, and domain name generator that fit alongside the existing favicon entry.

**Media Processing** — TinyTools includes an OG image generator and an AI background remover that runs fully in-browser via WebAssembly (images never leave the user''s device), which is a nice fit next to the existing OG Image Playground entry.

Happy to adjust placement or wording if you''d prefer something different — and feel free to merge only one of the two additions if both feel like too much.

Thanks!